### PR TITLE
added optional procedures; special handling of (delay (force ...))

### DIFF
--- a/srfi-155.html
+++ b/srfi-155.html
@@ -133,8 +133,9 @@ created.
   thread <code>this</code> in the code (as Python does with
   explicitely mentioning <em>self</em> at each method definition) or
   to realize <code>this</code> as a syntax parameter (see
-  <a href="https://srfi.schemers.org/srfi-139/srfi-139.html">SRFI 139</a>, a way C++ and Java have chosen.)  A third
-  way, more along Python's semantics but without explicitely
+  <a href="https://srfi.schemers.org/srfi-139/srfi-139.html">SRFI
+  139</a>, a way C++ and Java chose.)  A third way, more along
+  Python's semantics but without explicitely
   mentioning <code>this</code> (or <em>self</em>) at every method
   definition site would be to define <code>this</code> as a parameter
   object (in the sense of the R7RS), which is parameterized at each
@@ -152,11 +153,59 @@ created.
   remedied in form of &ldquo;arrow functions&rdquo;.)
 </p>
 
+<p>
+  However, there might be legitimate reasons to access the dynamic environment at the
+  site of the first invocation to <code>force</code>, for example for
+  debugging purposes.  Therefore, this SRFI defines an optional
+  procedure <code>forcing-environment</code>, which returns the dynamic environment (in the sense
+  of <a href="https://srfi.schemers.org/srfi-154/srfi-154.html">SRFI
+    154</a>) of the most recent call to <code>force</code>.
+  The procedure is optional because their presence complicates the
+  semantic model of lazy evaluation again.
+  Using <code>(forcing-environment)</code> makes code as the following possible:
+</p>
+
+<pre>
+  (import (scheme base)
+          (scheme write)
+          (srfi 154)
+          (srfi 155))  
+  (define current-logger (make-parameter #f))
+  (define (log msg) ((current-logger) msg))
+  (define (default-logger msg)
+    (display msg (current-error-port))
+    (newline (current-error-port)))
+  (define-syntax logged-delay
+    (syntax-rules ()
+      ((delay/logged expression)
+       (delay (begin (with-dynamic-environment (forcing-environment)
+                      (lambda ()
+                        (log "promised value calculated just now")))
+                     expression)))))  
+  (let ((p (delay 1)))
+    (parameterize ((current-logger default-logger))
+      (display "The answer is: ")
+      (display (+ (force p) 41))
+      (newline)))  
+</pre>
+
+<p>In particular, it is possible to implement the semantic model of
+  the R7RS in terms of the model of this SRFI when the
+  procedure <code>forcing-environment</code> is included.
+</p>
+
 <h1>Specification</h1>
 
 <p>We use the term <em>dynamic environment</em> as defined
   by <a href="https://srfi.schemers.org/srfi-154/srfi-154.html">SRFI
     154</a>.
+</p>
+
+<p>The mandatory identifiers defined by this specification are
+exported by the <code>(srfi 155)</code>.  The optional identifiers are
+exported by <code>(srfi 155 reflection)</code>.  If an implementation
+provides <code>(srfi 155 reflection)</code> it has to provide all
+optional identifiers.
 </p>
 
 <h2>Syntax</h2>
@@ -194,6 +243,12 @@ created.
       45</a> for a discussion.
 </i></p>
 
+<p>Implementations of this SRFI are, moreover, required to detect the
+combined expression type <code>(delay
+    (force <em>expression</em>))</code> statically and to rewrite it into
+  <code>(delay-force <em>expression</em>)</code>.
+</p>
+
 <h2>Procedures</h2>
 
 <p><code>(force <em>promise</em>)</code></p>
@@ -227,6 +282,21 @@ created.
   promise, it is returned.
 </p>
 
+<h3>Optional procedures</h3>
+
+<p><code>(forcing-environment)</code></p>
+
+<p>The <code>forcing-environment</code> returns the dynamic
+environment (as defined by <a href="">SRFI 154</a>) in effect at the
+most recent call to <code>force</code>.  It is an error to
+invoke <code>forcing-environment</code> outside the dynamic extent of
+a call to <code>force</code>.
+</p>
+
+<p><code>(dynamic-environment? <em>obj</em>)</code></p>
+
+<p>Type predicate for dynamic environments as exported by <codee>(srfi 154)</code>.</p>
+
 <h2>Feature identifiers</h2>
 
 <p>
@@ -247,7 +317,7 @@ created.
 <p>
   It is recommended by this SRFI that future extensions (<i>e.g.</i>
   <em>R7RS-large</em>) or revisions (<i>e.g.</i> <em>R8RS</em>) of the
-  R7RS correct the R7RS in the sense of this SRFI.
+  R7RS to correct the R7RS in the sense of this SRFI.
 </p>
 
 <h1>Implementation</h1>
@@ -257,6 +327,10 @@ created.
   by <code>(scheme lazy)</code> and the sample implementation of SRFI
   154.  By adding the sample implementation of SRFI 45, one would get
   an implementation of this SRFI for any R5RS system.
+</p>
+
+<p>
+  The sample implementation provides the optional procedures.
 </p>
 
 <h1>Acknowledgements</h1>

--- a/srfi/155/implementation.sld
+++ b/srfi/155/implementation.sld
@@ -1,4 +1,4 @@
-;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights Reserved. 
+;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights Reserved.
 
 ;; Permission is hereby granted, free of charge, to any person
 ;; obtaining a copy of this software and associated documentation
@@ -20,7 +20,13 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(define-library (srfi 155)
+(define-library (srfi 155 implementation)
   (export delay delay-force force
-	  make-promise promise?)
-  (import (srfi 155 implementation)))
+	  make-promise promise?
+	  forcing-environment dynamic-environment?)
+  (import (scheme base)
+	  (rename (scheme lazy)
+		  (delay scheme-delay)
+		  (delay-force scheme-delay-force))
+	  (srfi 154))
+  (include "implementation.scm"))

--- a/srfi/155/reflection.sld
+++ b/srfi/155/reflection.sld
@@ -1,4 +1,4 @@
-;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights Reserved. 
+;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights Reserved.
 
 ;; Permission is hereby granted, free of charge, to any person
 ;; obtaining a copy of this software and associated documentation
@@ -20,17 +20,6 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-
-(define-syntax delay
-  (syntax-rules ()
-    ((delay expression)
-     (let ((dynamic-environment (current-dynamic-environment)))
-       (scheme-delay
-	(with-dynamic-environment dynamic-environment (lambda () expression)))))))
-
-(define-syntax delay-force
-  (syntax-rules ()
-    ((delay expression)
-     (let ((dynamic-environment (current-dynamic-environment)))
-       (scheme-delay-force
-	(with-dynamic-environment dynamic-environment (lambda () expression)))))))
+(define-library (srfi 155 reflection)
+  (export forcing-environment dynamic-environment?)
+  (import (srfi 155 implementation)))

--- a/srfi/155/test.sld
+++ b/srfi/155/test.sld
@@ -24,7 +24,9 @@
   (export run-tests)
   (import (scheme base)
 	  (srfi 64)
-	  (srfi 155))
+	  (srfi 154)
+	  (srfi 155)
+	  (srfi 155 reflection))
   (begin
     (define integers
       (let next ((n 0))
@@ -67,5 +69,16 @@
       (test-assert (promise? p))
       (test-equal 6 (begin (set! x 10)
 			   (force p)))
+
+      (test-equal "Dynamic environments"
+	'(1 2)
+	(let ((x (make-parameter 1)))
+	  (let ((p
+		 (delay (list (x)
+			      (with-dynamic-environment (forcing-environment) (lambda ()
+										(x)))))))
+	    (parameterize
+		((x 2))
+	      (force p)))))
       
       (test-end))))


### PR DESCRIPTION
- Minor spelling/grammar fixes.
- Added optional procedure ‘forcing-environment’ that allows to implement the original R7RS semantics on top of SRFI 155.
- Added (orthogonal) requirement that implementations have to rewrite (delay (force ...)).