### PR TITLE
New draft: Major feature update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,14 @@
 
 .POSIX:
 
-.SILENT: check
+.SILENT: check check-racket
 
 SCHEME = chibi-scheme $(SCHEME_FLAGS)
 
+RACKET = racket $(RACKET_FLAGS)
+
 check:
 	$(SCHEME) tests.scm
+
+check-racket:
+	$(RACKET) tests.rkt

--- a/srfi-155.html
+++ b/srfi-155.html
@@ -338,7 +338,7 @@ a call to <code>force</code>.
 
 <p>
   Credit also goes to Philip L. Bewig for his fantastic and standard
-  setting SRFI 41 that provides an important use case for promises.
+  setting SRFI 41, which provides an important use case for promises.
 </p>
   
 <h1>Copyright</h1>

--- a/srfi-155.html
+++ b/srfi-155.html
@@ -20,7 +20,15 @@ Marc Nieper-Wi&szlig;kirchen
 
 <h1>Status</h1>
 
-<p>This SRFI is currently in <em>draft</em> status.  Here is <a href="http://srfi.schemers.org/srfi-process.html">an explanation</a> of each status that a SRFI can hold.  To provide input on this SRFI, please send email to <code><a href="mailto:srfi+minus+155+at+srfi+dotschemers+dot+org">srfi-155@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.  To subscribe to the list, follow <a href="http://srfi.schemers.org/srfi-list-subscribe.html">these instructions</a>.  You can access previous messages via the mailing list <a href="http://srfi-email.schemers.org/srfi-155">archive</a>.</p>
+<p>This SRFI is currently in <em>draft</em> status.  Here
+is <a href="http://srfi.schemers.org/srfi-process.html">an
+explanation</a> of each status that a SRFI can hold.  To provide input
+on this SRFI, please send email
+to <code><a href="mailto:srfi+minus+155+at+srfi+dotschemers+dot+org">srfi-155@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.
+To subscribe to the list,
+follow <a href="http://srfi.schemers.org/srfi-list-subscribe.html">these
+instructions</a>.  You can access previous messages via the mailing
+list <a href="http://srfi-email.schemers.org/srfi-155">archive</a>.</p>
 <ul>
   <li>Received: 2017/7/4</li>
   <li>60-day deadline: 2017/9/2</li>
@@ -43,19 +51,16 @@ non-functional, side effecting code.  It should, however, be
 applicable in a purely functional setting.  This is the case for the
 delayed evaluation model as described in the R7RS as long as no
 dynamically bound variables, also known as parameter objects, are
-present.  It is the purpose of this SRFI to rework the
-specification in the R7RS so that lazy evaluation works with purely
-functional code that makes use of dynamic environments.  This is done
-by remembering the dynamic environment in effect when
+present.  It is the purpose of this SRFI to rework the specification
+in the R7RS so that lazy evaluation works with purely functional code
+that makes use of dynamic environments or, more generally, the dynamic
+extent.  This is done by remembering the dynamic extent in effect when
 the <code>delay</code> expression is evaluated.
 </p>
 
 <h1>Issues</h1>
 
 <ul>
-  <li>The name of the described feature
-  identifier <code>functional-promises</code> is not yet set in
-    stone.</li>
   <li>Shall this SRFI define a compatibility library to SRFI 45,
     named, say, <code>(srfi 45 functional)</code>, that is equivalent to the
     following?
@@ -73,11 +78,11 @@ the <code>delay</code> expression is evaluated.
 <p>
 In <a href="http://trac.sacrideo.us/wg/ticket/397">ticket #397</a> of
 the Scheme Working Group 1, the question was raised how promises shall
-interact with the dynamic environment, namely
+interact with the dynamic extent, namely
 whether <code>force</code> shall evaluate a promise in the dynamic
-environment of the call to <code>force</code> which first requested its value.  An
+extent of the call to <code>force</code> which first requested its value.  An
 opposing choice would be that <code>force</code> shall evaluate a
-promise in the dynamic environment of the site where the promise was
+promise in the dynamic extent of the site where the promise was
 created.
 </p>
 
@@ -95,7 +100,8 @@ created.
   editors of the R7RS
   was <a href="https://groups.google.com/forum/#!topic/scheme-reports-wg2/CQslZcWTXHM">the
   wrong one</a>, so this SRFI proposes a correction to
-  the <code>(scheme lazy)</code> library.
+  the <code>(scheme lazy)</code> library in form of the <code>(scheme
+  promise)</code> library.
 </p>
 
 <p>Lazy algorithms should work well together with purely functional
@@ -154,15 +160,15 @@ created.
 </p>
 
 <p>
-  However, there might be legitimate reasons to access the dynamic environment at the
+  However, there might be legitimate reasons to access the dynamic extent at the
   site of the first invocation to <code>force</code>, for example for
   debugging purposes.  Therefore, this SRFI defines an optional
-  procedure <code>forcing-environment</code>, which returns the dynamic environment (in the sense
+  procedure <code>forcing-extent</code>, which returns the dynamic extent (in the sense
   of <a href="https://srfi.schemers.org/srfi-154/srfi-154.html">SRFI
     154</a>) of the most recent call to <code>force</code>.
   The procedure is optional because their presence complicates the
   semantic model of lazy evaluation again.
-  Using <code>(forcing-environment)</code> makes code as the following possible:
+  Using <code>(forcing-extent)</code> makes code as the following possible:
 </p>
 
 <pre>
@@ -196,16 +202,28 @@ created.
 
 <h1>Specification</h1>
 
-<p>We use the term <em>dynamic environment</em> as defined
-  by <a href="https://srfi.schemers.org/srfi-154/srfi-154.html">SRFI
-    154</a>.
+<p>We use the term <em>dynamic extent</em> for reified dynamic extents
+  as in <a href="https://srfi.schemers.org/srfi-154/srfi-154.html">SRFI
+  154</a>.
 </p>
 
 <p>The mandatory identifiers defined by this specification are
 exported by the <code>(srfi 155)</code>.  The optional identifiers are
 exported by <code>(srfi 155 reflection)</code>.  If an implementation
-provides <code>(srfi 155 reflection)</code> it has to provide all
+provides <code>(srfi 155 reflection)</code>, it has to provide all
 optional identifiers.
+</p>
+
+<p>
+  The author of this SRFI recommends that the interface described in
+  this SRFI will be made available under the namespace <code>(scheme
+  promise)</code> (and <code>(scheme promise reflection)</code>) in
+  future revisions of the Scheme programming language that build upon
+  the R7RS.  When this happens, <code>(scheme lazy)</code> might
+  become deprecated and remain solely for backward-compatibility with
+  the R7RS.  It is further recommended that <code>(scheme
+  stream)</code> of the R7RS-large uses the same semantics with
+  respect to the dynamic extent as this SRFI.
 </p>
 
 <h2>Syntax</h2>
@@ -216,7 +234,7 @@ optional identifiers.
   <code>(delay &lt;expression&gt;)</code> returns an object called
   a <em>promise</em> which at some point in the future can be asked
   (by the <code>force</code> procedure) to
-  evaluate <code>&lt;expression&gt;</code> in the dynamic environment
+  evaluate <code>&lt;expression&gt;</code> in the dynamic extent
   in effect when the <code>delay</code> expression was evaluated, and
   deliver the resulting value.  The effect
   of <code>&lt;expression&gt;</code> returning multiple values is
@@ -257,7 +275,7 @@ combined expression type <code>(delay
   a <em>promise</em> created
   by <code>delay</code>, <code>delay-force</code>,
   or <code>make-promise</code>.  If no value has been computed for the
-  promise, the value is computed in the dynamic environment in
+  promise, the value is computed in the dynamic extent in
   effect when the <code>delay</code>, <code>delay-force</code>,
   or <code>make-promise</code> expression was evaluated, and
   returned.  The value of the promise must be cached (or
@@ -284,10 +302,10 @@ combined expression type <code>(delay
 
 <h3>Optional procedures</h3>
 
-<p><code>(forcing-environment)</code></p>
+<p><code>(forcing-extent)</code></p>
 
-<p>The <code>forcing-environment</code> returns the dynamic
-environment (as defined by <a href="">SRFI 154</a>) in effect at the
+<p>The <code>forcing-extent</code> returns the dynamic
+extent (as defined by <a href="">SRFI 154</a>) in effect at the
 most recent call to <code>force</code>.  It is an error to
 invoke <code>forcing-environment</code> outside the dynamic extent of
 a call to <code>force</code>.
@@ -295,30 +313,7 @@ a call to <code>force</code>.
 
 <p><code>(dynamic-environment? <em>obj</em>)</code></p>
 
-<p>Type predicate for dynamic environments as exported by <codee>(srfi 154)</code>.</p>
-
-<h2>Feature identifiers</h2>
-
-<p>
-  An R7RS implementation that implements promises as described here as
-  part of its <code>(scheme lazy)</code> library provides the feature
-  identifier <code>functional-promises</code>.  In that case, the
-  bindings exported by <code>(srfi 155)</code>
-  are the same as the
-  respective bindings exported by <code>(scheme lazy)</code>.
-</p>
-
-<p>
-  Technically, such an R7RS implementation does not completely conform to
-  the small language as described by the R7RS.  Nevertheless, such an
-  implementation shall still provide the <code>r7rs</code> feature identifier.
-</p>
-
-<p>
-  It is recommended by this SRFI that future extensions (<i>e.g.</i>
-  <em>R7RS-large</em>) or revisions (<i>e.g.</i> <em>R8RS</em>) of the
-  R7RS to correct the R7RS in the sense of this SRFI.
-</p>
+<p>Type predicate for dynamic extent as exported by <codee>(srfi 154)</code>.</p>
 
 <h1>Implementation</h1>
 

--- a/srfi-155.html
+++ b/srfi-155.html
@@ -58,22 +58,20 @@ extent.  This is done by remembering the dynamic extent in effect when
 the <code>delay</code> expression is evaluated.
 </p>
 
+<p>
+  Another perceived misfeature of the R7RS model of delayed evaluation
+  is the apparent need of the <code>delay-force</code> special form to
+  express iterative lazy algorthms.  It is shown that
+  the <code>delay-force</code> special form is unneeded and that the
+  implementation can (and should) handle iterative lazy algorithms
+  without space leaks.
+</p>
+
 <h1>Issues</h1>
 
-<ul>
-  <li>Shall this SRFI define a compatibility library to SRFI 45,
-    named, say, <code>(srfi 45 functional)</code>, that is equivalent to the
-    following?
-<pre>
-  (define-library (srfi 45 functional) 
-    (export delay lazy force eager)
-    (import (rename (srfi 155) (delay-force lazy)
-                               (make-promise eager))))            
-</pre>
-  </li>
-</ul>
-
 <h1>Rationale</h1>
+
+<h2>Promises and the dynamic extent</h2>
 
 <p>
 In <a href="http://trac.sacrideo.us/wg/ticket/397">ticket #397</a> of
@@ -166,7 +164,7 @@ created.
   procedure <code>forcing-extent</code>, which returns the dynamic extent (in the sense
   of <a href="https://srfi.schemers.org/srfi-154/srfi-154.html">SRFI
     154</a>) of the most recent call to <code>force</code>.
-  The procedure is optional because their presence complicates the
+  The procedure is optional because its presence complicates the
   semantic model of lazy evaluation again.
   Using <code>(forcing-extent)</code> makes code as the following possible:
 </p>
@@ -200,6 +198,131 @@ created.
   procedure <code>forcing-environment</code> is included.
 </p>
 
+<h2>Iterative lazy algorithms</h2>
+
+<p>
+The R5RS and the R7RS make no guarantee that expressing iterative lazy
+algorithms just with <code>delay</code> and <code>force</code> will
+run in bounded space.  Instead, they provide a special
+form <code>delay-force</code> such that <code>(delay-force
+&lt;expression&gt;)</code> is equivalent to <code>(delay (force
+&lt;expression&gt;))</code> except forcing the resulting promise
+guarantees to evaluate <code>(force &lt;expression&gt;)</code> in tail
+position.  The R7RS gives an example in form of
+the <code>stream-filter</code> procedure that makes use of
+the <code>delay-force</code> form.
+</p>
+
+<p>
+From a user's perspective, the need for this third primitive is not
+optimal, and one may think that a Scheme system properly supporting
+delayed evaluation should handle <code>(delay (force
+&lt;expression&gt;))</code> as gracefully as it does handle calls in
+tail position (as described in section 3.5 of the R7RS).
+</p>
+
+<p>
+As an improvement, it was suggested by Alex Shinn on the mailing list
+of this SRFI that <code>delay</code> should be redefined along
+the following lines:
+</p>
+
+<pre>
+  (define-syntax delay
+    (syntax-rules (force)
+      ((delay (force expression))
+       (delay-force expression)
+      ((delay expression)
+       ...)))</pre>
+
+<p>
+  With this definition, during expansion of <code>delay</code> the system
+  statically detects whether the expression to be delayed is of the
+  form <code>(force &lt;expression&gt;)</code>. This means
+  that <code>delay-force</code> does not have to be exposed anymore
+  and that a Scheme user can write <code>(delay (force
+  &lt;expression&gt;))</code> instead of <code>(delay-force
+  &lt;expression&gt;)</code>.
+</p>
+
+<o>
+  Besides probably being more user-friendly, this redefinition of <code>delay</code>
+  makes the delayed evaluation model also more composable, hence more
+  powerful:  Consider, for example, the following code (making use of
+  <a href="https://srfi.schemers.org/srfi-111/srfi-111.html">SRFI 111:
+  Boxes</a>):
+</p>
+
+<pre>
+  (define-syntax lazy-box
+    (syntax-rules ()
+      ((lazy-box expression)
+       (box (delay expression)))))
+
+  (define-syntax lazy-unbox
+    (syntax-rules ()
+      ((lazy-unbox box)
+       (force (unbox box)))))</pre>
+
+<p>
+The lazy boxes defined by these two keywords wrap a promise in a box.
+The pair of <code>lazy-box</code> and <code>lazy-unbox</code> provides
+the same primitives for lazy boxes as do <code>delay</code>
+and <code>force</code> for non-boxed promises.  Using the suggested
+semantics that <code>(delay (force &lt;expression&gt;))</code> is
+equivalent to <code>(delay-force &lt;expression&gt;)</code>, the
+composition <code>(lazy-box (lazy-unbox &lt;expression&gt;))</code>
+reduces correctly and makes expressing iterative lazy algorithms with
+lazy boxes possible.
+</p>
+
+<p>
+In order to make this work, <code>lazy-unbox</code> has to be defined as
+syntax and not as a procedure.  Had we defined <code>lazy-unbox</code>
+as a procedure, the call to <code>force</code> in tail position would
+have remained hidden from the syntax expander.
+</p>
+
+<p>
+  While the automatic syntactic reduction of <code>(delay (force
+    &lt;expression&gt;))</code> to <code>(delay-force
+    &lt;expression&gt;)</code> is, as this example shows, better than
+  exposing <code>delay-force</code> directly, this necessity of having to
+  define ‘lazy-unbox’ as syntax also shows that the proposed
+  semantics is still a suboptimal choice.  Furthermore, the model
+  breaks down in more complicated cases:
+</p>
+
+<pre>
+  (delay (if flag? (force x) (force y)))</pre>
+ 
+<p>Forcing the result of this expression won't guarantee
+  that <code>(force x)</code> or <code>(force y)</code> are evaluated
+  in a tail position although both calls appear in tail context inside
+  the <code>delay</code> form.
+</p>
+
+<p>
+So again, from a user's perspective, this handling of <code>(delay
+(force &lt;expression&gt;))</code> is still not as graceful as it
+should be. The problem is that the previous solution is based on
+detecting the presence of <code>force</code> syntactically.
+</p>
+
+<p>Instead, what is needed is the following: If
+  evaluating <code>&lt;expression&gt;</code> results in a tail call of
+  the form <code>(force <em>promise</em>)</code>, forcing the result
+  of <code>(delay &lt;expression&gt;)</code> will also result in a
+  tail to <code>(force <em>promise</em>)</code>.
+</p>
+
+<p>It is not possible to achieve this syntactically.  It is, however,
+  possible to implement this requirement using the continuation marks
+  of <a href="https://srfi.schemers.org/srfi-157/srfi-157.html">SRFI
+    157</a>, which is demonstrated by the sample implementation
+  accompanying this SRFI.
+</p>
+
 <h1>Specification</h1>
 
 <p>We use the term <em>dynamic extent</em> for reified dynamic extents
@@ -208,9 +331,10 @@ created.
 </p>
 
 <p>The mandatory identifiers defined by this specification are
-exported by the <code>(srfi 155)</code>.  The optional identifiers are
-exported by <code>(srfi 155 reflection)</code>.  If an implementation
-provides <code>(srfi 155 reflection)</code>, it has to provide all
+exported by the library <code>(srfi 155)</code>.  The optional
+identifiers are exported by the library <code>(srfi 155
+reflection)</code>.  If an implementation provides the
+library <code>(srfi 155 reflection)</code>, it has to provide all
 optional identifiers.
 </p>
 
@@ -241,30 +365,25 @@ optional identifiers.
   unspecified.
 </p>
 
+<p>
+  If forcing the result of <code>(delay &lt;expression&gt;)</code>
+  results in a tail call of the form <code>(force
+    <em>promise</em>)</code>,  forcing of the result is required to
+  also result in a tail call to <code>(force <em>promise</em>)</code>.
+</p>
+
+<p><i>Rationale:</i> This makes iterative lazy algorithms without
+  space leaks possible; see
+  also <a href="https://srfi.schemers.org/srfi-45/srfi-45.html">SRFI
+  45</a>.
+</p>
+
 <p><code>(delay-force &lt;expression&gt;)</code></p>
 
 <p>
-  The expression <code>(delay-force &lt;expression&gt;)</code> is
-  conceptually similar to <code>(delay (force
-    &lt;expression&gt;))</code>), with the difference that forcing the
-  result of <code>delay-force</code> will in effect result in a tail
-  call to <code>(force &lt;expression&gt;)</code>, while forcing the
-  result of <code>(delay (force &lt;expression&gt;))</code> might
-  not.  Thus iterative lazy algorithms that might result in a long
-  series of chains of <code>delay</code> and <code>force</code> can be
-  rewritten using <code>delay-force</code> to prevent consuming
-  unbounded space during evaluation.
-</p>
-
-<p><i>See <a href="https://srfi.schemers.org/srfi-41/srfi-41.html">SRFI
-      41</a> and <a href="https://srfi.schemers.org/srfi-45/srfi-45.html">SRFI
-      45</a> for a discussion.
-</i></p>
-
-<p>Implementations of this SRFI are, moreover, required to detect the
-combined expression type <code>(delay
-    (force <em>expression</em>))</code> statically and to rewrite it into
-  <code>(delay-force <em>expression</em>)</code>.
+  Equivalent to <code>(delay (force &lt;expression&gt;))</code>.  This
+  form is provided only for backward compatibility, and its use is
+  deprecated.
 </p>
 
 <h2>Procedures</h2>
@@ -304,11 +423,19 @@ combined expression type <code>(delay
 
 <p><code>(forcing-extent)</code></p>
 
-<p>The <code>forcing-extent</code> returns the dynamic
-extent (as defined by <a href="">SRFI 154</a>) in effect at the
-most recent call to <code>force</code>.  It is an error to
-invoke <code>forcing-environment</code> outside the dynamic extent of
-a call to <code>force</code>.
+<p>When the value of a promise <code>(delay &lt;expression&gt;)</code>
+  is asked for the first time and <code>&lt;expression&gt;</code> is
+  evaluated, an invokation of <code>(forcing-extent)</code> in the
+  dynamic extent of that evaluation returns the dynamic extent (as
+  defined
+  by <a href="https://srfi.schemers.org/srfi-154/srfi-154.html">SRFI
+  154</a>) of the call to <code>force</code> that initially forced the
+  promise.  If forcing a promise yields a chain of <code>delay</code>
+  and <code>force</code>, the dynamic extent returned
+  by <code>(forcing-extent)</code> is the dynamic extent of the
+  outermost call to <code>force</code> in this chain.  It is an error
+  to invoke <code>forcing-environment</code> outside the dynamic
+  extent of <code>&lt;expression&gt;</code>.
 </p>
 
 <p><code>(dynamic-environment? <em>obj</em>)</code></p>
@@ -318,10 +445,31 @@ a call to <code>force</code>.
 <h1>Implementation</h1>
 
 <p>The provided <a href="srfi/155.sld">sample implementation</a> for
-  an R7RS system builds upon the native promise type as defined
-  by <code>(scheme lazy)</code> and the sample implementation of SRFI
-  154.  By adding the sample implementation of SRFI 45, one would get
-  an implementation of this SRFI for any R5RS system.
+  an R7RS system builds upon the sample implementation
+  of <a href="https://srfi.schemers.org/srfi-154/srfi-154.html">SRFI
+    154</a>.
+</p>
+
+<p>
+  It is a faithful implementation if the presence of the
+  library <code>(srfi 157)</code>
+  of <a href="https://srfi.schemers.org/srfi-157/srfi-157.html">SRFI
+    157: Continuation marks</a> is detected on the host system.
+</p>
+
+<p>
+  Otherwise, the requirement that <code>(force (delay
+    &lt;expression&gt;))</code> results in a tail call to <code>(force
+    <em>promise</em>)</code> whenever
+  evaluating <code>&lt;expression&gt;</code> results in a tail call
+  to <code>(force <em>promise</em>)</code> is only met
+  when <code>&lt;expression&gt;</code> expands into the
+  form <code>(force <em>promise</em>)</code>.
+</p>
+
+<p>
+  Their is also an interface to the implementation as
+  a <a href="srfi/155.rkt">Racket module</a>.
 </p>
 
 <p>
@@ -331,16 +479,19 @@ a call to <code>force</code>.
 <h1>Acknowledgements</h1>
 
 <p>
-  Credit goes to the authors of the R7RS and to Andr&eacute; van Tonder for his
-  SRFI 45 from where most of this SRFI's description of promises and delayed
+  Credit goes to the authors of the R7RS and to Andr&eacute; van
+  Tonder for his
+  <a href="https://srfi.schemers.org/srfi-41/srfi-41.html">SRFI 45</a>
+  from where most of this SRFI's description of promises and delayed
   evaluation was taken.
 </p>
 
 <p>
   Credit also goes to Philip L. Bewig for his fantastic and standard
-  setting SRFI 41, which provides an important use case for promises.
+  setting <a href="https://srfi.schemers.org/srfi-41/srfi-41.html">SRFI
+  41</a>, which provides an important use case for promises.
 </p>
-  
+
 <h1>Copyright</h1>
 Copyright (C) Marc Nieper-Wi&szlig;kirchen (2017).  All Rights Reserved. 
 

--- a/srfi-155.html
+++ b/srfi-155.html
@@ -302,7 +302,7 @@ a call to <code>force</code>.
 <p>
   An R7RS implementation that implements promises as described here as
   part of its <code>(scheme lazy)</code> library provides the feature
-  identifier <code>functional-identifiers</code>.  In that case, the
+  identifier <code>functional-promises</code>.  In that case, the
   bindings exported by <code>(srfi 155)</code>
   are the same as the
   respective bindings exported by <code>(scheme lazy)</code>.

--- a/srfi/154.chibi.scm
+++ b/srfi/154.chibi.scm
@@ -20,6 +20,19 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(define-library (srfi 155 reflection)
-  (export forcing-environment dynamic-extent?)
-  (import (srfi 155 implementation)))
+(define-record-type <dynamic-extent>
+  (make-dynamic-extent point)
+  dynamic-extent?
+  (point dynamic-extent-point))
+
+(define (current-dynamic-extent)
+  (make-dynamic-extent (%dk)))
+
+(define (with-dynamic-extent dynamic-extent thunk)
+  (let ((here (%dk)))
+    (travel-to-point! here (dynamic-extent-point dynamic-extent))
+    (%dk (dynamic-extent-point dynamic-extent))
+    (let ((result (thunk)))
+      (travel-to-point! (%dk) here)
+      (%dk here)
+      result)))

--- a/srfi/154.closed-lambda.scm
+++ b/srfi/154.closed-lambda.scm
@@ -20,6 +20,10 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(define-library (srfi 155 reflection)
-  (export forcing-environment dynamic-extent?)
-  (import (srfi 155 implementation)))
+(define-syntax closed-lambda
+  (syntax-rules ()
+    ((closed-lambda formals body)
+     (let ((dynamic-extent (current-dynamic-extent)))
+       (lambda formals
+	 (with-dynamic-extent dynamic-extent (lambda ()
+					       body)))))))

--- a/srfi/154.scm
+++ b/srfi/154.scm
@@ -1,4 +1,4 @@
-;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights Reserved. 
+;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights Reserved.
 
 ;; Permission is hereby granted, free of charge, to any person
 ;; obtaining a copy of this software and associated documentation
@@ -20,21 +20,13 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(define-syntax closed-lambda
-  (syntax-rules ()
-    ((closed-lambda formals body)
-     (let ((dynamic-environment (current-dynamic-environment)))
-       (lambda formals
-	 (with-dynamic-environment dynamic-environment (lambda ()
-							 body)))))))
-
-(define-record-type <dynamic-environment>
-  (make-dynamic-environment proc)
-  dynamic-environment?
-  (proc dynamic-environment-proc))
+(define-record-type <dynamic-extent>
+  (make-dynamic-extent proc)
+  dynamic-extent?
+  (proc dynamic-extent-proc))
 
 
-(define (current-dynamic-environment)
+(define (current-dynamic-extent)
   (call-with-current-continuation
    (lambda (return)
      (let-values
@@ -42,12 +34,12 @@
 	   (call-with-current-continuation
 	    (lambda (c)
 	       (return
-		(make-dynamic-environment (lambda (thunk)
+		(make-dynamic-extent (lambda (thunk)
 					    (call-with-current-continuation
 					     (lambda (k)
 					       (c k thunk))))))))))
        (call-with-values thunk k)))))
 
 
-(define (with-dynamic-environment dynamic-environment thunk)
-  ((dynamic-environment-proc dynamic-environment) thunk))
+(define (with-dynamic-extent dynamic-extent thunk)
+  ((dynamic-extent-proc dynamic-extent) thunk))

--- a/srfi/154.sld
+++ b/srfi/154.sld
@@ -1,4 +1,4 @@
-;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights Reserved. 
+;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights Reserved.
 
 ;; Permission is hereby granted, free of charge, to any person
 ;; obtaining a copy of this software and associated documentation
@@ -20,10 +20,17 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(define-library (srfi 154)
-  (export dynamic-environment?
-          current-dynamic-environment
-	  with-dynamic-environment
+(define-library (srfi 154)  
+  (export dynamic-extent?
+          current-dynamic-extent
+	  with-dynamic-extent
 	  closed-lambda)
-  (import (scheme base))
-  (include "154.scm"))
+  (cond-expand
+    (chibi
+     (import (scheme base)
+	     (only (chibi) travel-to-point! %dk))
+     (include "154.chibi.scm"))
+    (else
+     (import (scheme base))
+     (include "154.scm")))
+  (include "154.closed-lambda.scm"))

--- a/srfi/155.rkt
+++ b/srfi/155.rkt
@@ -20,11 +20,17 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(define-library (srfi 155 test)
-  (export run-tests)
-  (import (scheme base)
-	  (srfi 64)
-	  (srfi 154)
-	  (srfi 155)
-	  (srfi 155 reflection))
-  (include "test.scm"))
+#lang racket
+
+(provide delay
+	 delay-force
+	 force
+	 make-promise
+	 promise?
+	 forcing-extent
+	 dynamic-extent?)
+
+(require srfi/9
+	 "154.rkt")
+
+(include "155/implementation.157.scm")

--- a/srfi/155/implementation.157.scm
+++ b/srfi/155/implementation.157.scm
@@ -1,0 +1,111 @@
+;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights Reserved. 
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+
+;;; Data types
+
+(define-record-type <promise>
+  (%%make-promise content)
+  promise?
+  (content promise-content promise-set-content!))
+
+(define (%make-promise done? value dynamic-extent)
+  (%%make-promise (vector done? value dynamic-extent)))
+
+(define (promise-done? promise)
+  (vector-ref (promise-content promise) 0))
+
+(define (promise-value promise)
+  (vector-ref (promise-content promise) 1))
+
+(define (promise-dynamic-extent promise)
+  (vector-ref (promise-content promise) 2))
+
+(define (promise-set-done?! promise done?)
+  (vector-set! (promise-content promise) 0 done?))
+
+(define (promise-set-value! promise value)
+  (vector-set! (promise-content promise) 1 value))
+
+(define (promise-set-dynamic-extent! promise dynamic-extent)
+  (vector-set! (promise-content promise) 2 dynamic-extent))
+
+(define key (vector #f))
+
+;;; Internal parameters
+
+(define current-forcing-extent (make-parameter #f))
+
+;;; Internal procedures
+
+(define (promise-update! new old)
+  (promise-set-done?! old (promise-done? new))
+  (promise-set-value! old (promise-value new))
+  (promise-set-dynamic-extent! old (promise-dynamic-extent new))
+  (promise-set-content! new (promise-content old)))
+
+;;; Exported syntax
+
+(define-syntax delay
+  (syntax-rules ()
+    ((delay expr)
+     (%make-promise #f (lambda () expr) (current-dynamic-extent)))))
+
+(define-syntax delay-force
+  (syntax-rules ()
+    ((delay-force promise)
+     (delay (force promise)))))
+
+;;; Exported procedures
+
+(define (make-promise obj)
+  (%make-promise #t obj #f))
+
+(define (force promise)
+  (let ((forcing-extent (current-dynamic-extent)))
+    (let loop ((promise promise))
+      (if (promise-done? promise)
+	  (promise-value promise)
+	  (call-with-immediate-continuation-mark
+	   key
+	   (lambda (c)
+	     (if c
+		 (c promise)
+		 (let ((promise*
+			(call-with-current-continuation
+			 (lambda (c)
+			   (make-promise
+			    (with-dynamic-extent
+			     (promise-dynamic-extent promise)
+			     (lambda ()
+			       (parameterize ((current-forcing-extent forcing-extent))
+				 (with-continuation-mark key c
+							 ((promise-value promise)))))))))))
+		   (unless (promise-done? promise)
+		     (promise-update! promise* promise))
+		   (loop promise)))))))))
+
+(define (forcing-extent)
+  (unless (current-forcing-extent)
+    (error "forcing-extent: there is no promise being forced"))
+  (current-forcing-extent))
+

--- a/srfi/155/implementation.scm
+++ b/srfi/155/implementation.scm
@@ -20,12 +20,12 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(define current-forcing-environment (make-parameter #f))
+(define current-forcing-extent (make-parameter #f))
 
-(define (forcing-environment)
-  (unless (current-forcing-environment)
-    (error "forcing-environment: there is no promise being forced"))
-  (current-forcing-environment))
+(define (forcing-extent)
+  (unless (current-forcing-extent)
+    (error "forcing-extent: there is no promise being forced"))
+  (current-forcing-extent))
 
 (define-syntax delay
   (syntax-rules (force)
@@ -34,11 +34,11 @@
     ((delay expression)
      (let ((dynamic-extent (current-dynamic-extent)))
        (scheme-delay
-	(let ((forcing-environment (current-dynamic-extent)))
+	(let ((forcing-extent (current-dynamic-extent)))
 	  (with-dynamic-extent dynamic-extent (lambda ()
 						(parameterize
-						    ((current-forcing-environment
-						      forcing-environment))
+						    ((current-forcing-extent
+						      forcing-extent))
 						  expression)))))))))
 
 (define-syntax delay-force
@@ -46,9 +46,9 @@
     ((delay expression)
      (let ((dynamic-extent (current-dynamic-extent)))
        (scheme-delay-force
-	(let ((forcing-environment (current-dynamic-extent)))
+	(let ((forcing-extent (current-dynamic-extent)))
 	  (with-dynamic-extent dynamic-extent (lambda ()
 						(parameterize
-						    ((current-forcing-environment
-						      forcing-environment))
+						    ((current-forcing-extent
+						      forcing-extent))
 						  expression)))))))))

--- a/srfi/155/implementation.scm
+++ b/srfi/155/implementation.scm
@@ -32,23 +32,23 @@
     ((delay (force expression))
      (delay-force expression))
     ((delay expression)
-     (let ((dynamic-environment (current-dynamic-environment)))
+     (let ((dynamic-extent (current-dynamic-extent)))
        (scheme-delay
-	(let ((forcing-environment (current-dynamic-environment)))
-	  (with-dynamic-environment dynamic-environment (lambda ()
-							  (parameterize
-							      ((current-forcing-environment
-								forcing-environment))
-							    expression)))))))))
+	(let ((forcing-environment (current-dynamic-extent)))
+	  (with-dynamic-extent dynamic-extent (lambda ()
+						(parameterize
+						    ((current-forcing-environment
+						      forcing-environment))
+						  expression)))))))))
 
 (define-syntax delay-force
   (syntax-rules ()
     ((delay expression)
-     (let ((dynamic-environment (current-dynamic-environment)))
+     (let ((dynamic-extent (current-dynamic-extent)))
        (scheme-delay-force
-	(let ((forcing-environment (current-dynamic-environment)))
-	  (with-dynamic-environment dynamic-environment (lambda ()
-							  (parameterize
-							      ((current-forcing-environment
-								forcing-environment))
-							    expression)))))))))
+	(let ((forcing-environment (current-dynamic-extent)))
+	  (with-dynamic-extent dynamic-extent (lambda ()
+						(parameterize
+						    ((current-forcing-environment
+						      forcing-environment))
+						  expression)))))))))

--- a/srfi/155/implementation.sld
+++ b/srfi/155/implementation.sld
@@ -23,7 +23,7 @@
 (define-library (srfi 155 implementation)
   (export delay delay-force force
 	  make-promise promise?
-	  forcing-environment dynamic-environment?)
+	  forcing-environment dynamic-extent?)
   (import (scheme base)
 	  (rename (scheme lazy)
 		  (delay scheme-delay)

--- a/srfi/155/implementation.sld
+++ b/srfi/155/implementation.sld
@@ -23,7 +23,7 @@
 (define-library (srfi 155 implementation)
   (export delay delay-force force
 	  make-promise promise?
-	  forcing-environment dynamic-extent?)
+	  forcing-extent dynamic-extent?)
   (import (scheme base)
 	  (rename (scheme lazy)
 		  (delay scheme-delay)

--- a/srfi/155/implementation.sld
+++ b/srfi/155/implementation.sld
@@ -25,8 +25,13 @@
 	  make-promise promise?
 	  forcing-extent dynamic-extent?)
   (import (scheme base)
-	  (rename (scheme lazy)
-		  (delay scheme-delay)
-		  (delay-force scheme-delay-force))
 	  (srfi 154))
-  (include "implementation.scm"))
+  (cond-expand
+    ((library (srfi 157))
+     (import (srfi 157))
+     (include "implementation.157.scm"))
+    (else
+     (import (rename (scheme lazy)
+		     (delay scheme-delay)
+		     (delay-force scheme-delay-force)))
+     (include "implementation.lazy.scm"))))

--- a/srfi/155/reflection.sld
+++ b/srfi/155/reflection.sld
@@ -21,5 +21,5 @@
 ;; SOFTWARE.
 
 (define-library (srfi 155 reflection)
-  (export forcing-environment dynamic-extent?)
+  (export forcing-extent dynamic-extent?)
   (import (srfi 155 implementation)))

--- a/srfi/155/test.rkt
+++ b/srfi/155/test.rkt
@@ -20,11 +20,12 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(define-library (srfi 155 test)
-  (export run-tests)
-  (import (scheme base)
-	  (srfi 64)
-	  (srfi 154)
-	  (srfi 155)
-	  (srfi 155 reflection))
-  (include "test.scm"))
+#lang racket
+
+(provide run-tests)
+
+(require srfi/64
+	 "../154.rkt"
+	 "../155.rkt")
+
+(include "test.scm")

--- a/srfi/155/test.scm
+++ b/srfi/155/test.scm
@@ -1,0 +1,82 @@
+;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights Reserved. 
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(define integers
+  (let next ((n 0))
+    (delay (cons n (next (+ n 1))))))
+
+(define (head stream)
+  (car (force stream)))
+
+(define (tail stream)
+  (cdr (force stream)))
+
+(define (stream-filter p? s)
+  (delay-force
+   (if (null? (force s))
+       (delay '())
+       (let ((h (car (force s)))
+	     (t (cdr (force s))))
+	 (if (p? h)
+	     (delay (cons h (stream-filter p? t)))
+	     (stream-filter p? t))))))
+
+(define (run-tests)
+
+  (define count 0)
+  (define p
+    (delay (begin (set! count (+ count 1))
+		  (if (> count x)
+		      count
+		      (force p)))))
+  (define x 5)
+  
+  (test-begin "SRFI 155: Promises")
+
+  (test-equal 3 (force (delay (+ 1 2))))
+  (test-equal '(3 3)
+    (let ((p (delay (+ 1 2))))
+      (list (force p) (force p))))
+  (test-equal 2 (head (tail (tail integers))))
+  (test-equal 5 (head (tail (tail (stream-filter odd? integers)))))
+
+  (test-assert (promise? p))
+  (test-equal 6 (force p))
+  (test-assert (promise? p))
+  (test-equal 6 (begin (set! x 10)
+		       (force p)))
+
+  (test-equal "Dynamic extents"
+    '((1 2) 2)
+    (let ((x (make-parameter 1)))
+      (let ((p
+	     (delay-force (delay (list (x)
+				       (with-dynamic-extent (forcing-extent)
+							    (lambda () (x)))))))
+	    (q (delay (with-dynamic-extent (forcing-extent) (lambda () (x))))))
+	(parameterize
+	    ((x 2))
+	  (list 
+	   (force (delay-force p))
+	   (force q))))))
+  
+  (test-end))

--- a/srfi/155/test.sld
+++ b/srfi/155/test.sld
@@ -75,7 +75,7 @@
 	(let ((x (make-parameter 1)))
 	  (let ((p
 		 (delay (list (x)
-			      (with-dynamic-extent (forcing-environment)
+			      (with-dynamic-extent (forcing-extent)
 						   (lambda () (x)))))))
 	    (parameterize
 		((x 2))

--- a/srfi/155/test.sld
+++ b/srfi/155/test.sld
@@ -70,13 +70,13 @@
       (test-equal 6 (begin (set! x 10)
 			   (force p)))
 
-      (test-equal "Dynamic environments"
+      (test-equal "Dynamic extents"
 	'(1 2)
 	(let ((x (make-parameter 1)))
 	  (let ((p
 		 (delay (list (x)
-			      (with-dynamic-environment (forcing-environment) (lambda ()
-										(x)))))))
+			      (with-dynamic-extent (forcing-environment)
+						   (lambda () (x)))))))
 	    (parameterize
 		((x 2))
 	      (force p)))))

--- a/tests.rkt
+++ b/tests.rkt
@@ -20,11 +20,9 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(define-library (srfi 155 test)
-  (export run-tests)
-  (import (scheme base)
-	  (srfi 64)
-	  (srfi 154)
-	  (srfi 155)
-	  (srfi 155 reflection))
-  (include "test.scm"))
+#lang racket
+
+(require (rename-in "srfi/155/test.rkt"
+		    (run-tests run-srfi-155-tests)))
+
+(run-srfi-155-tests)


### PR DESCRIPTION
The new draft incorporates a major improvement to the semantics of the pair `delay` and `force`, making `delay-force` unnecessary.  It is shown through an efficient sample implementation that a Scheme system can ensure that iterative lazy algorithms run in bounded space without needing the aid of the user (by writing `delay-force`).

Other changes:
- Use the new terminology of SRFI 154, which replaces _dynamic environment_ by _dynamic extent_.
- Update included sample implementation of SRFI 154.
- Update sample R7RS implementation to the new semantics, requiring SRFI 157 for complete correctness.
- Provide a Racket module.
- Clarify semantics of `(forcing-extent)`.
